### PR TITLE
change torch version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-torch==0.3
+torch==0.3.1
 numpy
 pandas
 attrs


### PR DESCRIPTION
torch 0.3 is now disappeared from pipy, so pip install -r requirements.txt fails.
0.3.1 seems to work fine.
